### PR TITLE
fix: InfluxDB error handling and support for the cloud version

### DIFF
--- a/cylc-src/bioreactor-workflow/flow.cylc
+++ b/cylc-src/bioreactor-workflow/flow.cylc
@@ -32,7 +32,7 @@
         """
         +P3/P1 = quantify & quantify[-P1] & quantify[-P2] => compute_fluxes
 {% if cfg__toggle_influxdb %}
-        R1/^ = validate_cfg => setup_influxdb_cfg => ping_influxdb => create_bucket => is_setup
+        R1/^ = validate_cfg => setup_influxdb_cfg => create_bucket => is_setup
         +P1/P1 = """
             extract_features => upload_features
             quantify => upload_concentrations
@@ -273,16 +273,6 @@
             title = Setup InfluxDB Configuration
             description = """
                 Creates an InfluxDB configuration file based on user-defined variables.
-            """
-            categories = influxdb
-
-    [[ping_influxdb]]
-        inherit = INFLUXDB
-        script = influx ping --configs-path ${configs_path} --active-config ${config_name}
-        [[[meta]]]
-            title = Ping InfluxDB Server
-            description = """
-                Checks the connection to the InfluxDB server defined by the user.
             """
             categories = influxdb
 

--- a/cylc-src/bioreactor-workflow/lib/python/influx_utils.py
+++ b/cylc-src/bioreactor-workflow/lib/python/influx_utils.py
@@ -22,12 +22,6 @@ handler = logging.StreamHandler()
 handler.setFormatter(logging.Formatter("%(asctime)s | %(message)s"))
 loggerSerializer.addHandler(handler)
 
-# Configuration
-URL = "http://localhost:8086"
-TOKEN = "HlkyCQBW_F8Ri_UyOlyNDDVNZg93uEXDwpT6CQ1My4Hdx8cW2vx6wTM_duzcf3rn2y88H7a3ZZJ-N_q4_mV14g=="
-ORG = "FluxoMet"
-BUCKET = "testing-py-api"
-
 
 def client_from_ini(ini_path: str, config_name: str = "influx2"):
     """

--- a/cylc-src/bioreactor-workflow/lib/python/influx_utils.py
+++ b/cylc-src/bioreactor-workflow/lib/python/influx_utils.py
@@ -7,20 +7,49 @@ import logging
 from datetime import datetime
 from pathlib import Path
 from dataclasses import dataclass
+from threading import Event
+from typing import Optional
 import json
-import pandas as pd
 
+import pandas as pd
 from influxdb_client import InfluxDBClient
+from influxdb_client.client.exceptions import InfluxDBError
+from urllib3 import HTTPResponse
 
 
 # Enable logging for DataFrame serializer
-loggerSerializer = logging.getLogger(
+HANDLER = logging.StreamHandler()
+HANDLER.setFormatter(logging.Formatter("%(asctime)s | %(message)s"))
+LOGGERSERIALIZER = logging.getLogger(
     "influxdb_client.client.write.dataframe_serializer"
 )
-loggerSerializer.setLevel(level=logging.DEBUG)
-handler = logging.StreamHandler()
-handler.setFormatter(logging.Formatter("%(asctime)s | %(message)s"))
-loggerSerializer.addHandler(handler)
+LOGGERSERIALIZER.setLevel(level=logging.DEBUG)
+LOGGERSERIALIZER.addHandler(HANDLER)
+
+
+class BatchingCallback:
+    """
+    copied from:
+    https://influxdb-client.readthedocs.io/en/latest/usage.html#handling-errors
+    """
+
+    def __init__(self):
+        self.error_event = Event()
+        self.response: Optional[HTTPResponse] = None
+        self.message: Optional[str] = None
+
+    def success(self, conf: tuple[str, str, str], data: str):
+        pass
+
+    def error(self, conf: tuple[str, str, str], data: str, exception: InfluxDBError):
+        self.error_event.set()
+        self.response = exception.response
+        self.message = exception.message
+
+    def retry(self, conf: tuple[str, str, str], data: str, exception: InfluxDBError):
+        self.error_event.set()
+        self.response = exception.response
+        self.message = exception.message
 
 
 def client_from_ini(ini_path: str, config_name: str = "influx2"):
@@ -81,7 +110,12 @@ def ingest(
     measurement_df: MeasurementDataFrame, client: InfluxDBClient, bucket: str
 ) -> None:
     start_time = datetime.now()
-    with client.write_api() as write_api:
+    callback = BatchingCallback()
+    with client.write_api(
+        success_callback=callback.success,
+        error_callback=callback.error,
+        retry_callback=callback.retry,
+    ) as write_api:
         write_api.write(
             bucket=bucket,
             record=measurement_df.data_frame,
@@ -89,4 +123,6 @@ def ingest(
             data_frame_measurement_name=measurement_df.measurement_name,
             data_frame_timestamp_column=measurement_df.time_col,
         )
-    print(f"Import finished in: {datetime.now() - start_time}")
+    if callback.error_event.is_set():
+        raise InfluxDBError(callback.response, callback.message)
+    print(f"Successfully finished upload in: {datetime.now() - start_time}")


### PR DESCRIPTION
Closes #14.

Also make the InfluxDB upload tasks properly fail if an error occurs. It previously didn't, because the WriteAPI in batch mode is asynchronous and so no python exception was raised.