### PR TITLE
Refactor InfluxDB tasks

### DIFF
--- a/cylc-src/bioreactor-workflow/bin/influxdb-bucket
+++ b/cylc-src/bioreactor-workflow/bin/influxdb-bucket
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+
+import os
+
+from influxdb_client import InfluxDBClient, BucketsApi
+from influxdb_client.client.exceptions import InfluxDBError
+
+
+BUCKET_NAME = os.getenv("BUCKET_NAME", "no_bucket_name_given")
+# Other environment variables are read with InfluxDBClient.from_env_properties
+
+
+def main():
+    client = InfluxDBClient.from_env_properties()
+    bucket_api: BucketsApi = client.buckets_api()
+    try:
+        bucket_api.create_bucket(bucket_name=BUCKET_NAME)
+    except InfluxDBError as e:
+        raise Error(f"Failed to create bucket {BUCKET_NAME}: {e}")
+
+
+if __name__ == "__main__":
+    main()

--- a/cylc-src/bioreactor-workflow/bin/influxdb-bucket
+++ b/cylc-src/bioreactor-workflow/bin/influxdb-bucket
@@ -6,7 +6,7 @@ from influxdb_client import InfluxDBClient, BucketsApi
 from influxdb_client.client.exceptions import InfluxDBError
 
 REUSE_BUCKET = os.getenv("REUSE_BUCKET", "False").lower() == "true"
-BUCKET_NAME = os.getenv("BUCKET_NAME", "no_bucket_name_given")
+BUCKET_NAME = os.getenv("BUCKET_NAME")
 # Other environment variables are read with InfluxDBClient.from_env_properties :
 # INFLUXDB_V2_URL
 # INFLUXDB_V2_ORG

--- a/cylc-src/bioreactor-workflow/bin/influxdb-bucket
+++ b/cylc-src/bioreactor-workflow/bin/influxdb-bucket
@@ -5,18 +5,25 @@ import os
 from influxdb_client import InfluxDBClient, BucketsApi
 from influxdb_client.client.exceptions import InfluxDBError
 
-
+REUSE_BUCKET = os.getenv("REUSE_BUCKET", "False").lower() == "true"
 BUCKET_NAME = os.getenv("BUCKET_NAME", "no_bucket_name_given")
-# Other environment variables are read with InfluxDBClient.from_env_properties
+# Other environment variables are read with InfluxDBClient.from_env_properties :
+# INFLUXDB_V2_URL
+# INFLUXDB_V2_ORG
+# INFLUXDB_V2_TOKEN
 
 
 def main():
+    """Create an InfluxDB bucket."""
     client = InfluxDBClient.from_env_properties()
     bucket_api: BucketsApi = client.buckets_api()
     try:
         bucket_api.create_bucket(bucket_name=BUCKET_NAME)
     except InfluxDBError as e:
-        raise Error(f"Failed to create bucket {BUCKET_NAME}: {e}")
+        if REUSE_BUCKET and e.response.status == 422:
+            print(f"Bucket {BUCKET_NAME} already exists, skipping creation.")
+        else:
+            raise e
 
 
 if __name__ == "__main__":

--- a/cylc-src/bioreactor-workflow/bin/influxdb-bucket
+++ b/cylc-src/bioreactor-workflow/bin/influxdb-bucket
@@ -5,7 +5,7 @@ import os
 from influxdb_client import InfluxDBClient, BucketsApi
 from influxdb_client.client.exceptions import InfluxDBError
 
-REUSE_BUCKET = os.getenv("REUSE_BUCKET", "False").lower() == "true"
+REUSE_BUCKET = os.getenv("reuse_bucket", "False").lower() == "true"
 BUCKET_NAME = os.getenv("BUCKET_NAME")
 # Other environment variables are read with InfluxDBClient.from_env_properties :
 # INFLUXDB_V2_URL

--- a/cylc-src/bioreactor-workflow/bin/influxdb-upload
+++ b/cylc-src/bioreactor-workflow/bin/influxdb-upload
@@ -1,9 +1,12 @@
 #!/usr/bin/env python3
 
+import os
 import argparse
 from pathlib import Path
 
 import influx_utils
+
+BUCKET_NAME = os.getenv("BUCKET_NAME", "no_bucket_name_given")
 
 
 def main():
@@ -12,19 +15,15 @@ def main():
     )
     parser.add_argument("--table", type=str, help="Table name to ingest.")
     parser.add_argument("--dir", type=Path, help="Path to directory with CSV tables.")
-    parser.add_argument("--ini", type=Path, help="Path to InfluxDB ini config.")
     parser.add_argument(
         "--schemas", type=Path, help="Path to JSON with tables schemas."
-    )
-    parser.add_argument(
-        "--bucket", type=str, help="Name of the bucket to ingest the data."
     )
 
     args = parser.parse_args()
     schemas = influx_utils.load_tables_schemas(args.schemas)
     measurement_df = influx_utils.measurement_df_from_csv(schemas, args.table, args.dir)
-    client = influx_utils.client_from_ini(args.ini)
-    influx_utils.ingest(measurement_df, client, args.bucket)
+    client = influx_utils.client_from_env()
+    influx_utils.ingest(measurement_df, client, bucket=BUCKET_NAME)
 
 
 if __name__ == "__main__":

--- a/cylc-src/bioreactor-workflow/bin/influxdb-upload
+++ b/cylc-src/bioreactor-workflow/bin/influxdb-upload
@@ -1,29 +1,30 @@
 #!/usr/bin/env python3
 
 import os
-import argparse
-from pathlib import Path
 
+from influxdb_client import InfluxDBClient
 import influx_utils
+from influx_utils import MeasurementDataFrame
 
-BUCKET_NAME = os.getenv("BUCKET_NAME", "no_bucket_name_given")
+BUCKET_NAME = os.getenv("BUCKET_NAME")
+SCHEMAS = os.getenv("SCHEMAS")
+RESULTS_DIR = os.getenv("RESULTS_DIR")
+TABLE = os.getenv("table")
+# Other environment variables are read with InfluxDBClient.from_env_properties :
+# INFLUXDB_V2_URL
+# INFLUXDB_V2_ORG
+# INFLUXDB_V2_TOKEN
 
 
 def main():
-    parser = argparse.ArgumentParser(
-        prog="influxdb-upload", description="Upload CSV to InfluxDB."
-    )
-    parser.add_argument("--table", type=str, help="Table name to ingest.")
-    parser.add_argument("--dir", type=Path, help="Path to directory with CSV tables.")
-    parser.add_argument(
-        "--schemas", type=Path, help="Path to JSON with tables schemas."
-    )
-
-    args = parser.parse_args()
-    schemas = influx_utils.load_tables_schemas(args.schemas)
-    measurement_df = influx_utils.measurement_df_from_csv(schemas, args.table, args.dir)
-    client = influx_utils.client_from_env()
-    influx_utils.ingest(measurement_df, client, bucket=BUCKET_NAME)
+    """
+    Upload a CSV file to InfluxDB, using the specified schema to specify tags
+    and fields.
+    """
+    schemas = influx_utils.load_tables_schemas(SCHEMAS)
+    measurement_df = MeasurementDataFrame.from_csv(schemas, TABLE, RESULTS_DIR)
+    with InfluxDBClient.from_env_properties() as client:
+        influx_utils.ingest(measurement_df, client, bucket=BUCKET_NAME)
 
 
 if __name__ == "__main__":

--- a/cylc-src/bioreactor-workflow/bin/influxdb-upload
+++ b/cylc-src/bioreactor-workflow/bin/influxdb-upload
@@ -3,13 +3,12 @@
 import os
 
 from influxdb_client import InfluxDBClient
-import influx_utils
 from influx_utils import MeasurementDataFrame
 
 BUCKET_NAME = os.getenv("BUCKET_NAME")
-SCHEMAS = os.getenv("SCHEMAS")
-RESULTS_DIR = os.getenv("RESULTS_DIR")
-TABLE = os.getenv("table")
+SCHEMAS = os.getenv("SCHEMAS_JSON")
+SCHEMA_NAME = os.getenv("schema")
+CSV = os.getenv("table")
 # Other environment variables are read with InfluxDBClient.from_env_properties :
 # INFLUXDB_V2_URL
 # INFLUXDB_V2_ORG
@@ -21,10 +20,9 @@ def main():
     Upload a CSV file to InfluxDB, using the specified schema to specify tags
     and fields.
     """
-    schemas = influx_utils.load_tables_schemas(SCHEMAS)
-    measurement_df = MeasurementDataFrame.from_csv(schemas, TABLE, RESULTS_DIR)
+    measurement_df = MeasurementDataFrame.from_csv(CSV, SCHEMAS, SCHEMA_NAME)
     with InfluxDBClient.from_env_properties() as client:
-        influx_utils.ingest(measurement_df, client, bucket=BUCKET_NAME)
+        measurement_df.upload(client, bucket=BUCKET_NAME)
 
 
 if __name__ == "__main__":

--- a/cylc-src/bioreactor-workflow/flow.cylc
+++ b/cylc-src/bioreactor-workflow/flow.cylc
@@ -10,10 +10,6 @@
 # Create task families for conda environments.
     %include 'envs/conda.cylc'
 
-[task parameters]
-    #main_results = peaks, concentrations, fluxes, metadata
-    results = features, concentrations
-
 [scheduling]
     cycling mode = integer
     initial cycle point = 0
@@ -285,32 +281,46 @@
 
     [[create_bucket]]
         inherit = INFLUXDB
-        script = """
-            echo "Creating InfluxDB bucket for workflow run!"
-            influxdb-bucket
-        """
+        script = influxdb-bucket
         [[[meta]]]
             title = Create InfluxDB Bucket
             description = """
                 Creates a bucket in InfluxDB dedicated to the current workflow run.
             """
             categories = influxdb
-
-    [[upload<results>]]
-        inherit = INFLUXDB, CONDA_INFLUX
-        script = """
-            influxdb-upload \
-                --table ${table} \
-                --dir ${dir} \
-                --schemas ${schemas} \
-        """
+    
+    [[UPLOAD_TABLE]]
+        inherit = INFLUXDB
+        script = influxdb-upload
         [[[environment]]]
-            table = ${CYLC_TASK_PARAM_results}
-            dir = ${MAIN_RESULTS_DIR}
-            schemas = ${META_DIR}/result_tables.json
+            table = _ # Defined in child tasks
+            SCHEMAS = ${META_DIR}/result_tables.json
+            RESULTS_DIR = ${MAIN_RESULTS_DIR}
         [[[meta]]]
-            title = Upload <results>
+            title = UPLOAD TABLE (family task)
             description = """
-                Uploads results table to InfluxDB.
+                Family task. Upload a CSV table to InfluxDB.
+            """
+            categories = family task, influxdb
+
+    [[upload_features]]
+        inherit = UPLOAD_TABLE
+        [[[environment]]]
+            table = features
+        [[[meta]]]
+            title = Upload Features Table
+            description = """
+                Uploads the features table to InfluxDB.
+            """
+            categories = influxdb
+    
+    [[upload_concentrations]]
+        inherit = UPLOAD_TABLE
+        [[[environment]]]
+            table = concentrations
+        [[[meta]]]
+            title = Upload Concentrations Table
+            description = """
+                Uploads the concentrations table to InfluxDB.
             """
             categories = influxdb

--- a/cylc-src/bioreactor-workflow/flow.cylc
+++ b/cylc-src/bioreactor-workflow/flow.cylc
@@ -289,7 +289,7 @@
                 Creates a bucket in InfluxDB dedicated to the current workflow run.
             """
             categories = influxdb
-    
+
     [[UPLOAD_TABLE]]
         inherit = INFLUXDB
         script = influxdb-upload
@@ -315,7 +315,7 @@
                 Uploads the features table to InfluxDB.
             """
             categories = influxdb
-    
+
     [[upload_concentrations]]
         inherit = UPLOAD_TABLE
         [[[environment]]]

--- a/cylc-src/bioreactor-workflow/flow.cylc
+++ b/cylc-src/bioreactor-workflow/flow.cylc
@@ -270,15 +270,16 @@
         inherit = None, CONDA_INFLUX
         [[[environment]]]
             BUCKET_NAME = ${CYLC_WORKFLOW_ID}
-            # Env variables recognized by the InfluxDB Python library.
+            REUSE_BUCKET = {{ cfg__influxdb_reuse_bucket }}
+            # Canonical environment variables recognized by the InfluxDB Python library.
             INFLUXDB_V2_URL = {{ cfg__influxdb_url }}
             INFLUXDB_V2_ORG = {{ cfg__influxdb_org }}
             INFLUXDB_V2_TOKEN = {{ cfg__influxdb_auth_token }}
         [[[meta]]]
             title = INFLUXDB (family task)
             description = """
-                Family task to inherit InfluxDB configuration and workflow-specific bucket, in the
-                form of environment variables.
+                Family task to inherit InfluxDB client configuration and workflow-specific bucket,
+                in the form of environment variables.
             """
             categories = family task, influxdb
 

--- a/cylc-src/bioreactor-workflow/flow.cylc
+++ b/cylc-src/bioreactor-workflow/flow.cylc
@@ -30,7 +30,7 @@
 {% if cfg__toggle_influxdb %}
         R1/^ = validate_cfg => create_bucket => is_setup
         +P1/P1 = """
-            extract_features => upload_features
+            annotate => upload_features
             quantify => upload_concentrations
         """
         # +P3/P1 = """
@@ -266,7 +266,6 @@
         inherit = None, CONDA_INFLUX
         [[[environment]]]
             BUCKET_NAME = ${CYLC_WORKFLOW_ID}
-            REUSE_BUCKET = {{ cfg__influxdb_reuse_bucket }}
             # Canonical environment variables recognized by the InfluxDB Python library.
             INFLUXDB_V2_URL = {{ cfg__influxdb_url }}
             INFLUXDB_V2_ORG = {{ cfg__influxdb_org }}
@@ -282,6 +281,8 @@
     [[create_bucket]]
         inherit = INFLUXDB
         script = influxdb-bucket
+        [[[environment]]]
+            reuse_bucket = {{ cfg__influxdb_reuse_bucket }}
         [[[meta]]]
             title = Create InfluxDB Bucket
             description = """
@@ -293,9 +294,9 @@
         inherit = INFLUXDB
         script = influxdb-upload
         [[[environment]]]
+            SCHEMAS_JSON = ${META_DIR}/result_tables.json
             table = _ # Defined in child tasks
-            SCHEMAS = ${META_DIR}/result_tables.json
-            RESULTS_DIR = ${MAIN_RESULTS_DIR}
+            schema = _ # Defined in child tasks
         [[[meta]]]
             title = UPLOAD TABLE (family task)
             description = """
@@ -306,7 +307,8 @@
     [[upload_features]]
         inherit = UPLOAD_TABLE
         [[[environment]]]
-            table = features
+            table = ${MAIN_RESULTS_DIR}/${RAWFILE_STEM}.features.annotated.csv
+            schema = features
         [[[meta]]]
             title = Upload Features Table
             description = """
@@ -317,7 +319,8 @@
     [[upload_concentrations]]
         inherit = UPLOAD_TABLE
         [[[environment]]]
-            table = concentrations
+            table = ${MAIN_RESULTS_DIR}/${RAWFILE_STEM}.concentrations.csv
+            schema = concentrations
         [[[meta]]]
             title = Upload Concentrations Table
             description = """

--- a/cylc-src/bioreactor-workflow/flow.cylc
+++ b/cylc-src/bioreactor-workflow/flow.cylc
@@ -32,7 +32,7 @@
         """
         +P3/P1 = quantify & quantify[-P1] & quantify[-P2] => compute_fluxes
 {% if cfg__toggle_influxdb %}
-        R1/^ = validate_cfg => setup_influxdb_cfg => create_bucket => is_setup
+        R1/^ = validate_cfg => create_bucket => is_setup
         +P1/P1 = """
             extract_features => upload_features
             quantify => upload_concentrations
@@ -267,46 +267,26 @@
     # InfluxDB tasks
 
     [[INFLUXDB]]
+        inherit = None, CONDA_INFLUX
         [[[environment]]]
-            configs_path = ${ROSE_DATA}/influxdb-config.ini
-            config_name = influx2
-            bucket_name = ${CYLC_WORKFLOW_ID}
+            BUCKET_NAME = ${CYLC_WORKFLOW_ID}
+            # Env variables recognized by the InfluxDB Python library.
+            INFLUXDB_V2_URL = {{ cfg__influxdb_url }}
+            INFLUXDB_V2_ORG = {{ cfg__influxdb_org }}
+            INFLUXDB_V2_TOKEN = {{ cfg__influxdb_auth_token }}
         [[[meta]]]
             title = INFLUXDB (family task)
             description = """
-                Family task to inherit InfluxDB configuration and workflow-specific bucket.
+                Family task to inherit InfluxDB configuration and workflow-specific bucket, in the
+                form of environment variables.
             """
             categories = family task, influxdb
-
-    [[setup_influxdb_cfg]]
-        inherit = INFLUXDB
-        script = """
-            influx config create \
-                --config-name ${config_name} \
-                --configs-path ${configs_path} \
-                --host-url ${host_url} \
-                --token ${token} \
-                --org ${org}
-        """
-        [[[environment]]]
-            host_url = {{ cfg__influxdb_url }}
-            token = {{ cfg__influxdb_auth_token }}
-            org = {{ cfg__influxdb_org }}
-        [[[meta]]]
-            title = Setup InfluxDB Configuration
-            description = """
-                Creates an InfluxDB configuration file based on user-defined variables.
-            """
-            categories = influxdb
 
     [[create_bucket]]
         inherit = INFLUXDB
         script = """
             echo "Creating InfluxDB bucket for workflow run!"
-            influx bucket create \
-                --name ${bucket_name} \
-                --configs-path ${configs_path} \
-                --active-config ${config_name}
+            influxdb-bucket
         """
         [[[meta]]]
             title = Create InfluxDB Bucket
@@ -319,8 +299,6 @@
         inherit = INFLUXDB, CONDA_INFLUX
         script = """
             influxdb-upload \
-                --ini ${configs_path} \
-                --bucket ${bucket_name} \
                 --table ${table} \
                 --dir ${dir} \
                 --schemas ${schemas} \

--- a/cylc-src/bioreactor-workflow/lib/python/influx_utils.py
+++ b/cylc-src/bioreactor-workflow/lib/python/influx_utils.py
@@ -52,6 +52,13 @@ class BatchingCallback:
         self.message = exception.message
 
 
+def client_from_env(*args, **kwargs):
+    """
+    Create client from environment variables.
+    """
+    return InfluxDBClient.from_env_properties(*args, **kwargs)
+
+
 def client_from_ini(ini_path: str, config_name: str = "influx2"):
     """
     Create client from ini file.

--- a/cylc-src/bioreactor-workflow/meta/result_tables.json
+++ b/cylc-src/bioreactor-workflow/meta/result_tables.json
@@ -1,8 +1,6 @@
 {
-    "sep": ";",
     "tables": {
         "features": {
-            "suffix": "features.csv",
             "datetime_column": "datetime",
             "fields": {
                 "cycle": "int",
@@ -15,11 +13,11 @@
                 "instrument_id",
                 "polarity",
                 "bin",
-                "merged_peak"
+                "merged_peak",
+                "annotated"
             ]
         },
         "concentrations": {
-            "suffix": "concentrations.csv",
             "datetime_column": "datetime",
             "fields": {
                 "cycle": "int",
@@ -38,7 +36,6 @@
             ]
         },
         "cycles_metadata": {
-            "suffix": "metadata.csv",
             "datetime_column": "datetime",
             "fields": {
                 "cycle": "int",
@@ -47,7 +44,6 @@
             }
         },
         "workflow_run": {
-            "suffix": "run_metadata.csv",
             "datetime_column": "datetime",
             "fields": {
                 "run_directory": "str",

--- a/cylc-src/bioreactor-workflow/meta/rose-meta.conf
+++ b/cylc-src/bioreactor-workflow/meta/rose-meta.conf
@@ -9,6 +9,10 @@ type=character
 compulsory=false
 type=character
 
+[template variables=cfg__influxdb_reuse_bucket]
+compulsory=false
+type=python_boolean
+
 [template variables=cfg__influxdb_url]
 compulsory=false
 type=character

--- a/cylc-src/bioreactor-workflow/rose-suite.conf
+++ b/cylc-src/bioreactor-workflow/rose-suite.conf
@@ -105,6 +105,7 @@ cfg__influxdb_org='my-organization'
 # :optional: yes
 # :default: None
 # :type: str
+cfg__influxdb_auth_token=''
 
 # Should the workflow reuse the InfluxDB bucket if it already exists. By default,
 # the workflow will create a new bucket with the same name as the run. If there

--- a/cylc-src/bioreactor-workflow/rose-suite.conf
+++ b/cylc-src/bioreactor-workflow/rose-suite.conf
@@ -35,7 +35,8 @@ cfg__tic_threshold=0.70
 # 'start-end' in scan numbers (eg. '10-20'). If **cfg_trim_values** is set, this
 # interval refers to scan numbers AFTER trimming.
 #
-# :optional: True
+# :optional: yes
+# :default: None
 # :type: str
 cfg__scans_window=''
 
@@ -62,7 +63,7 @@ cfg__input_strategy='internal'
 # in the one defined here that shares the same name as the :term:`workflow run`,
 # the workflow will look for .raw files inside.
 #
-# :optional: True
+# :optional: yes
 # :default: None
 # :type: str (path)
 cfg__local_runs_dir=''
@@ -86,14 +87,14 @@ cfg__toggle_influxdb=False
 
 # URL of the running InfluxDB instance.
 #
-# :optional: True
+# :optional: yes
 # :default: None
 # :type: str (URL)
 cfg__influxdb_url='http://localhost:8086'
 
 # Organization to write to in the InfluxDB instance. Must exist already.
 #
-# :optional: True
+# :optional: yes
 # :default: None
 # :type: str
 cfg__influxdb_org='my-organization'
@@ -101,7 +102,16 @@ cfg__influxdb_org='my-organization'
 # Authorization token for the InfluxDB instance. Must have complete write access
 # to the organization, in order to create buckets and write data.
 #
-# :optional: True
+# :optional: yes
 # :default: None
 # :type: str
-cfg__influxdb_auth_token='my-token'
+
+# Should the workflow reuse the InfluxDB bucket if it already exists. By default,
+# the workflow will create a new bucket with the same name as the run. If there
+# is already one, an error will be raised. If set to *True*, it will skip creation.
+# This can have unexpected consequences if datapoints are overwritten.
+#
+# :optional: yes
+# :default: False
+# :type: bool
+cfg__influxdb_reuse_bucket=False


### PR DESCRIPTION
This PR:
- Removes `influx` CLI from the workflow dependencies (can't be installed with conda) and uses the python API instead.
- Refactors everything related to the upload of csv tables to InfluxDB. Should be a lot clearer now.